### PR TITLE
feat: add vulpea-para project

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -43,6 +43,12 @@ const projects: Project[] = [
     tags: ['Emacs', 'Vulpea', 'Journaling'],
   },
   {
+    name: 'vulpea-para',
+    repo: 'vulpea-para',
+    description: 'PARA for your org notes, without the filing. Brings the PARA method (Projects, Areas, Resources, Archives) to Emacs on top of vulpea—organize notes without moving files around.',
+    tags: ['Emacs', 'Vulpea', 'Productivity'],
+  },
+  {
     name: 'flyspell-correct',
     repo: 'flyspell-correct',
     description: 'Distraction-free spell-checking interface for Emacs. Provides an intuitive way to correct spelling mistakes without leaving your workflow.',


### PR DESCRIPTION
Adds the d12frosted/vulpea-para project to the Projects page, placed alongside the other vulpea projects. The PARA method on top of vulpea.

Star count is fetched automatically from GitHub via the existing ISR setup; tags map to the mp-blue accent like its siblings. Description drawn from the repo's GitHub description.