### PR TITLE
feat: link talks.d12frosted.io from home and projects pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,6 +87,23 @@ export default async function Home() {
           </p>
         </div>
       </a>
+
+      <a
+        href="https://talks.d12frosted.io"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group block overflow-hidden bg-paper transition-all hover:shadow-lg"
+      >
+        <div className="h-1 bg-mp-blue" />
+        <div className="p-4">
+          <h3 className="mb-1 font-bold text-ink transition-colors group-hover:text-mp-blue dark:text-white dark:group-hover:text-mp-blue">
+            Talks
+          </h3>
+          <p className="text-sm leading-relaxed text-ink-muted">
+            Slides and recordings from public talks.
+          </p>
+        </div>
+      </a>
     </>
   )
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -204,6 +204,23 @@ export default async function Projects() {
             Visit Tasogare.ink →
           </a>
         </div>
+
+        <div className="border-l-4 border-mp-blue bg-paper p-8 lg:p-10">
+          <h3 className="mb-4 text-2xl font-bold tracking-tight text-ink dark:text-white">
+            Talks
+          </h3>
+          <p className="mb-6 leading-relaxed text-ink-muted">
+            Slides and recordings from public talks on Emacs, tooling, and software.
+          </p>
+          <a
+            href="https://talks.d12frosted.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 font-mono text-sm uppercase tracking-wider text-ink transition-colors hover:text-mp-blue dark:text-white dark:hover:text-mp-blue"
+          >
+            Visit Talks →
+          </a>
+        </div>
       </div>
     </>
   )


### PR DESCRIPTION
Adds links to the new public talks site at https://talks.d12frosted.io.

- **Home page**: new Talks card in the Projects section, after Barberry Garden (mp-blue accent, matching the existing card style).
- **Projects page**: new Talks callout in the bottom grid alongside Barberry Garden and Tasogare, which also balances that grid to 4 cards.

Both open in a new tab with `rel="noopener noreferrer"`, consistent with the other external links.